### PR TITLE
Fix/elytrariptidefp

### DIFF
--- a/src/main/java/org/samo_lego/golfiv/mixin_checks/movement/ServerPlayNetworkHandlerMixin_ElytraFlightCheck.java
+++ b/src/main/java/org/samo_lego/golfiv/mixin_checks/movement/ServerPlayNetworkHandlerMixin_ElytraFlightCheck.java
@@ -48,7 +48,7 @@ public class ServerPlayNetworkHandlerMixin_ElytraFlightCheck {
             cancellable = true
     )
     private void checkElytraMovement(PlayerMoveC2SPacket packet, CallbackInfo ci) {
-        if(golfConfig.movement.checkElytraFlight && player.isFallFlying() && data.getLastMovement() != null && data.getPacketMovement().getY() > data.getLastMovement().getY()) {
+        if(golfConfig.movement.checkElytraFlight && player.isFallFlying() && data.getLastMovement() != null && data.getPacketMovement().getY() > data.getLastMovement().getY() && !player.isUsingRiptide()) {
             if(usedRocket) {
                 usedRocket = false;
             }


### PR DESCRIPTION

https://user-images.githubusercontent.com/71787666/105618722-a0519980-5db8-11eb-967f-5302854e3d70.mp4

Simply skips the elytra check if the player is in the riptide state. Fixes #27 