### PR TITLE
fix build always failing on prs

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -2,7 +2,7 @@
 
 name: Javadoc
 
-on: [pull_request, push]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
Removes `on: pull_request` because prs will never be able to publish to javadoc dir on gh-pages branch