### PR TITLE
Add prevention of destruction by headless pistons.

### DIFF
--- a/src/main/java/org/samo_lego/golfiv/mixin/PistonMixin_PreventDestruction.java
+++ b/src/main/java/org/samo_lego/golfiv/mixin/PistonMixin_PreventDestruction.java
@@ -1,0 +1,26 @@
+package org.samo_lego.golfiv.mixin;// Created 2021-08-06T02:20:50
+
+import net.minecraft.block.Blocks;
+import net.minecraft.block.PistonBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import static org.samo_lego.golfiv.GolfIV.golfConfig;
+
+/**
+ * Prevents a headless piston from breaking blocks on block updates.
+ *
+ * @author KJP12
+ **/
+@Mixin(PistonBlock.class)
+public class PistonMixin_PreventDestruction {
+    @Redirect(method = "onSyncedBlockEvent", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;removeBlock(Lnet/minecraft/util/math/BlockPos;Z)Z"))
+    private boolean redirectWorld(World world, BlockPos pos, boolean move) {
+        if(!golfConfig.main.preventDestructionByHeadlessPistons || world.getBlockState(pos).isOf(Blocks.PISTON_HEAD)) {
+            return world.removeBlock(pos, move);
+        } else return false;
+    }
+}

--- a/src/main/java/org/samo_lego/golfiv/storage/GolfConfig.java
+++ b/src/main/java/org/samo_lego/golfiv/storage/GolfConfig.java
@@ -28,6 +28,10 @@ public class GolfConfig {
          * (e. g. hitting, typing, etc.)
          */
         public boolean checkInventoryActions = true;
+
+        public final String _comment_preventDestructionByPiston = "// Prevents headless pistons from destroying blocks that are not piston extensions.";
+
+        public boolean preventDestructionByHeadlessPistons = true;
     }
 
     /**
@@ -203,7 +207,7 @@ public class GolfConfig {
             try(
                     FileInputStream fileInputStream = new FileInputStream(configFile);
                     InputStreamReader inputStreamReader = new InputStreamReader(fileInputStream, StandardCharsets.UTF_8);
-                    BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+                    BufferedReader bufferedReader = new BufferedReader(inputStreamReader)
             ) {
                 golfConfig = GSON.fromJson(bufferedReader, GolfConfig.class);
             }

--- a/src/main/resources/golfiv.mixins.json
+++ b/src/main/resources/golfiv.mixins.json
@@ -4,6 +4,7 @@
   "package": "org.samo_lego.golfiv.mixin",
   "compatibilityLevel": "JAVA_8",
   "mixins": [
+    "PistonMixin_PreventDestruction",
     "ServerPlayerEntityMixinCast_Golfer",
     "ServerPlayNetworkHandlerMixin_PacketEvents",
     "accessors.EntityAccessor",


### PR DESCRIPTION
This allows server owners to disable pistons being able to break any blocks by adding a check to see if the would-be head is actually a piston head. Direction isn't tested, but could be added on if need be.