### PR TITLE
Fix/Insufficient NBT Patch

### DIFF
--- a/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
+++ b/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
@@ -1,8 +1,14 @@
 package org.samo_lego.golfiv.casts;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.ShulkerBoxBlock;
 import net.minecraft.item.*;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.potion.PotionUtil;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 
 /**
  * Checks iItemStacks.
@@ -46,5 +52,158 @@ public interface ItemStackChecker {
         }
 
         return fakedStack;
+    }
+
+    /**
+     * Creates a fake ItemStack based on the
+     * provided stack.
+     *
+     * Changes the tag to be the minimal required
+     * NBT to render in an inventory.
+     *
+     * @param stack The original ItemStack.
+     * @return The faked ItemStack
+     * */
+    static ItemStack inventoryStack(ItemStack stack) {
+        // TODO: Perhaps take a more dynamic approach to this?
+        //  This is not really flexible as is and may leave modded items broken.
+        NbtCompound tag = stack.getTag();
+        if(tag == null || tag.isEmpty()) {
+            // Sanitization isn't necessary when it's already empty.
+            return stack;
+        }
+
+        Item item = stack.getItem();
+        ItemStack fake = new ItemStack(item, stack.getCount());
+
+        // Rewrite display.
+        if(tag.contains(ItemStack.DISPLAY_KEY)) {
+            NbtCompound display = tag.getCompound(ItemStack.DISPLAY_KEY);
+            NbtCompound fakeDisplay = new NbtCompound();
+            NbtElement name = display.get(ItemStack.NAME_KEY);
+            if(name != null) fakeDisplay.put(ItemStack.NAME_KEY, name);
+            if(display.contains(ItemStack.COLOR_KEY)) fakeDisplay.put(ItemStack.COLOR_KEY, display.get(ItemStack.COLOR_KEY));
+            NbtElement lore = display.get(ItemStack.LORE_KEY);
+            if(lore != null) fakeDisplay.put(ItemStack.LORE_KEY, lore);
+            fake.putSubTag(ItemStack.DISPLAY_KEY, fakeDisplay);
+        }
+
+        // Rewrite enchantments.
+        if(stack.hasEnchantments()) {
+            NbtList enchants = new NbtList();
+            for(NbtElement enchant : stack.getEnchantments()) {
+                if(enchant instanceof NbtCompound) {
+                    NbtCompound compound = (NbtCompound) enchant;
+                    String id = compound.getString(ItemStack.ID_KEY);
+                    int lvl = compound.getInt(ItemStack.LVL_KEY);
+                    if(Registry.ENCHANTMENT.containsId(new Identifier(id))) {
+                        NbtCompound minimalEnchant = new NbtCompound();
+                        minimalEnchant.putString(ItemStack.ID_KEY, id);
+                        minimalEnchant.putInt(ItemStack.LVL_KEY, lvl);
+                        enchants.add(minimalEnchant);
+                    }
+                }
+            }
+            fake.putSubTag(ItemStack.ENCHANTMENTS_KEY, enchants);
+        }
+
+        // Rewrite damage if it is damageable.
+        if(stack.isDamageable()) {
+            fake.setDamage(stack.getDamage());
+        }
+
+        // Check block items.
+        if(item instanceof BlockItem) {
+            boolean flag = true;
+            if(item instanceof BannerItem) {
+                flag = false;
+                NbtCompound blockEntity = stack.getSubTag("BlockEntityTag");
+                if (blockEntity != null && blockEntity.contains("Patterns", NbtElement.LIST_TYPE)) {
+                    NbtList fakePatterns = new NbtList();
+                    for(NbtElement pattern : blockEntity.getList("Patterns", NbtElement.COMPOUND_TYPE)) {
+                        if(!(pattern instanceof NbtCompound)) continue;
+                        NbtCompound oldPattern = (NbtCompound) pattern;
+                        if (oldPattern.contains("Color", NbtElement.INT_TYPE) &&
+                                oldPattern.contains("Pattern", NbtElement.STRING_TYPE)) {
+                            if(oldPattern.getSize() == 2) {
+                                fakePatterns.add(oldPattern);
+                            } else {
+                                NbtCompound fakePattern = new NbtCompound();
+                                fakePattern.put("Color", oldPattern.get("Color"));
+                                fakePattern.put("Pattern", oldPattern.get("Pattern"));
+                                fakePatterns.add(fakePattern);
+                            }
+                        }
+                    }
+                    fake.getOrCreateSubTag("BlockEntityTag").put("Patterns", fakePatterns);
+                }
+            }
+
+            if(flag) {
+                Block block = ((BlockItem) item).getBlock();
+
+                // Rewrite shulker items
+                if (block instanceof ShulkerBoxBlock) {
+                    NbtCompound blockEntity = stack.getSubTag("BlockEntityTag");
+                    if(blockEntity != null) {
+                        NbtCompound fakeEntity = fake.getOrCreateSubTag("BlockEntityTag");
+                        if(blockEntity.contains("LootTable", NbtElement.STRING_TYPE)) {
+                            fakeEntity.put("LootTable", blockEntity.get("LootTable"));
+                        }
+                        if(blockEntity.contains("Items", NbtElement.LIST_TYPE)) {
+                            NbtList fakeItems = new NbtList();
+                            for(NbtElement $item : blockEntity.getList("Items", NbtElement.COMPOUND_TYPE)) {
+                                if($item == null) continue;
+                                NbtCompound oldItem = (NbtCompound) $item;
+                                NbtCompound fakeItem = new NbtCompound();
+                                if(oldItem.contains("Slot", NbtElement.BYTE_TYPE)) fakeItem.put("Slot", oldItem.get("Slot"));
+                                if(oldItem.contains("id", NbtElement.STRING_TYPE)) fakeItem.put("id", oldItem.get("id"));
+                                if(oldItem.contains("Count", NbtElement.BYTE_TYPE)) fakeItem.put("Count", oldItem.get("Count"));
+                                // TODO: Add in display name
+                                fakeItems.add(fakeItem);
+                            }
+                            fakeEntity.put("Items", fakeItems);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Rewrite potion effects.
+        if(item instanceof PotionItem || item instanceof TippedArrowItem) {
+            if(tag.contains("Potion", NbtElement.STRING_TYPE)) fake.putSubTag("Potion", tag.get("Potion"));
+            if(tag.contains("CustomPotionColor", NbtElement.INT_TYPE)) fake.putSubTag("CustomPotionColor", tag.get("CustomPotionColor"));
+            if(tag.contains("CustomPotionEffects", NbtElement.LIST_TYPE)) {
+                NbtList fakeEffects = new NbtList();
+                for(NbtElement effect : tag.getList("CustomPotionEffects", NbtElement.COMPOUND_TYPE)) {
+                    if(effect == null) continue;
+                    NbtCompound oldEffect = (NbtCompound) effect;
+                    NbtCompound fakeEffect = new NbtCompound();
+                    if(oldEffect.contains("Id", NbtElement.STRING_TYPE)) fakeEffect.put("Id", oldEffect.get("Id"));
+                    if(oldEffect.contains("Amplifier", NbtElement.BYTE_TYPE)) fakeEffect.put("Amplifier", oldEffect.get("Amplifier"));
+                    if(oldEffect.contains("Duration", NbtElement.INT_TYPE)) fakeEffect.put("Duration", oldEffect.get("Duration"));
+                    fakeEffects.add(fakeEffect);
+                }
+                fake.putSubTag("CustomPotionEffects", fakeEffects);
+            }
+        }
+
+        // Brokenly rewrites written books.
+        if(item instanceof WrittenBookItem) {
+            if(tag.contains("title", NbtElement.STRING_TYPE)) fake.putSubTag("title", tag.get("title"));
+            if(tag.contains("author", NbtElement.STRING_TYPE)) fake.putSubTag("author", tag.get("author"));
+            if(tag.contains("generation", NbtElement.INT_TYPE)) fake.putSubTag("generation", tag.get("generation"));
+            // FIXME: Pages need to be present for the book to work. Force update on selection?
+            // Prevents issues with other mods expecting pages to be present.
+            fake.putSubTag("pages", new NbtList());
+        }
+
+        if(item instanceof WritableBookItem) {
+            // FIXME: Pages need to be present for the book to work. Force update on selection?
+            // Prevents issues with other mods expecting pages to be present.
+            fake.putSubTag("pages", new NbtList());
+        }
+
+        return fake;
     }
 }

--- a/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
+++ b/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
@@ -1,6 +1,9 @@
 package org.samo_lego.golfiv.casts;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.PotionItem;
+import net.minecraft.item.TippedArrowItem;
+import net.minecraft.potion.PotionUtil;
 
 /**
  * Checks iItemStacks.
@@ -31,6 +34,10 @@ public interface ItemStackChecker {
 
         if(original.hasEnchantments())
             fakedStack.addEnchantment(null, 0);
+
+        if(original.getItem() instanceof PotionItem || original.getItem() instanceof TippedArrowItem) {
+            fakedStack.getOrCreateTag().putInt("CustomPotionColor", PotionUtil.getColor(original));
+        }
 
         return fakedStack;
     }

--- a/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
+++ b/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
@@ -41,6 +41,13 @@ public interface ItemStackChecker {
             fakedStack.addEnchantment(null, 0);
 
         Item item = original.getItem();
+        if(item instanceof DyeableItem) {
+            DyeableItem dyeable = (DyeableItem) item;
+            if(dyeable.hasColor(original)) {
+                dyeable.setColor(fakedStack, dyeable.getColor(original));
+            }
+        }
+
         if(item instanceof PotionItem || item instanceof TippedArrowItem) {
             // Lets dropping potions and arrows to be less of a 'surprising' change.
             fakedStack.getOrCreateTag().putInt("CustomPotionColor", PotionUtil.getColor(original));

--- a/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
+++ b/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
@@ -1,8 +1,7 @@
 package org.samo_lego.golfiv.casts;
 
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.PotionItem;
-import net.minecraft.item.TippedArrowItem;
+import net.minecraft.item.*;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.potion.PotionUtil;
 
 /**
@@ -35,8 +34,15 @@ public interface ItemStackChecker {
         if(original.hasEnchantments())
             fakedStack.addEnchantment(null, 0);
 
-        if(original.getItem() instanceof PotionItem || original.getItem() instanceof TippedArrowItem) {
+        Item item = original.getItem();
+        if(item instanceof PotionItem || item instanceof TippedArrowItem) {
+            // Lets dropping potions and arrows to be less of a 'surprising' change.
             fakedStack.getOrCreateTag().putInt("CustomPotionColor", PotionUtil.getColor(original));
+        }
+
+        if(item instanceof WritableBookItem || item instanceof WrittenBookItem) {
+            // Prevents issues with other mods expecting pages to be present.
+            fakedStack.putSubTag("pages", new NbtList());
         }
 
         return fakedStack;

--- a/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
+++ b/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
@@ -190,6 +190,10 @@ public interface ItemStackChecker {
             fake.putSubTag("pages", new NbtList());
         }
 
+        if(item instanceof FilledMapItem) {
+            fake.getOrCreateTag().putInt("map", tag.getInt("map"));
+        }
+
         return fake;
     }
 

--- a/src/main/java/org/samo_lego/golfiv/event/S2CPacket/EntityTrackerDataPatch.java
+++ b/src/main/java/org/samo_lego/golfiv/event/S2CPacket/EntityTrackerDataPatch.java
@@ -4,19 +4,28 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.Saddleable;
+import net.minecraft.entity.boss.WitherEntity;
 import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.passive.IronGolemEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.Packet;
 import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.MathHelper;
 import org.samo_lego.golfiv.mixin.accessors.EntityTrackerUpdateS2CPacketAccessor;
 import org.samo_lego.golfiv.mixin.accessors.ItemEntityAccessor;
+import org.samo_lego.golfiv.mixin.accessors.LivingEntityAccessor;
+import org.samo_lego.golfiv.mixin.accessors.PlayerEntityAccessor;
 
 import static org.samo_lego.golfiv.GolfIV.golfConfig;
 import static org.samo_lego.golfiv.casts.ItemStackChecker.fakeStack;
 
 public class EntityTrackerDataPatch implements S2CPacketCallback {
+    private static TrackedData<Float> LIVING_ENTITY_HEALTH = LivingEntityAccessor.getHealth();
+    private static TrackedData<Float> PLAYER_ENTITY_ABSORPTION = PlayerEntityAccessor.getAbsorption();
+    private static TrackedData<ItemStack> ITEM_ENTITY_STACK = ItemEntityAccessor.getSTACK();
 
     public EntityTrackerDataPatch() {
     }
@@ -37,14 +46,23 @@ public class EntityTrackerDataPatch implements S2CPacketCallback {
             Entity entity = player.getServerWorld().getEntityById(p.getId());
 
             if(golfConfig.packet.removeHealthTags && entity instanceof LivingEntity && entity.isAlive() && !(entity instanceof Saddleable)) {
-                p.getTrackedValues().removeIf(trackedValue -> trackedValue.getData().getId() == 8); // Health
-                p.getTrackedValues().removeIf(trackedValue -> trackedValue.getData().getId() == 12); // Absorption health
+                p.getTrackedValues().removeIf(trackedValue -> trackedValue.getData().equals(LIVING_ENTITY_HEALTH));
+                p.getTrackedValues().removeIf(trackedValue -> trackedValue.getData().equals(PLAYER_ENTITY_ABSORPTION));
+                if(entity instanceof IronGolemEntity || entity instanceof WitherEntity) {
+                    // Reinjects the health data aligned to quarters.
+                    LivingEntity ironGolem = (LivingEntity) entity;
+
+                    Float newHealth = MathHelper.floor((ironGolem.getHealth() - 1F) / 25F) * 25F + 1F;
+
+                    DataTracker.Entry<Float> fakeEntry = new DataTracker.Entry<>(LIVING_ENTITY_HEALTH, newHealth);
+                    p.getTrackedValues().add(fakeEntry);
+                }
             } else if(golfConfig.packet.removeDroppedItemInfo && entity instanceof ItemEntity) {
-                boolean removed = p.getTrackedValues().removeIf(entry -> entry.getData().getId() == 7); // Original item
+                boolean removed = p.getTrackedValues().removeIf(entry -> entry.getData().equals(ITEM_ENTITY_STACK)); // Original item
                 if(removed) {
                     ItemStack original = ((ItemEntity) entity).getStack();
 
-                    DataTracker.Entry<ItemStack> fakeEntry = new DataTracker.Entry<>(ItemEntityAccessor.getSTACK(), fakeStack(original, false));
+                    DataTracker.Entry<ItemStack> fakeEntry = new DataTracker.Entry<>(ITEM_ENTITY_STACK, fakeStack(original, false));
                     p.getTrackedValues().add(fakeEntry);
                 }
             }

--- a/src/main/java/org/samo_lego/golfiv/event/S2CPacket/ItemInventoryKickPatch.java
+++ b/src/main/java/org/samo_lego/golfiv/event/S2CPacket/ItemInventoryKickPatch.java
@@ -167,6 +167,14 @@ public class ItemInventoryKickPatch implements S2CPacketCallback {
                         if(tag.contains("author", NbtElement.STRING_TYPE)) fake.putSubTag("author", tag.get("author"));
                         if(tag.contains("generation", NbtElement.INT_TYPE)) fake.putSubTag("generation", tag.get("generation"));
                         // FIXME: Pages need to be present for the book to work. Force update on selection?
+                        // Prevents issues with other mods expecting pages to be present.
+                        fake.putSubTag("pages", new NbtList());
+                    }
+
+                    if(item instanceof WritableBookItem) {
+                        // FIXME: Pages need to be present for the book to work. Force update on selection?
+                        // Prevents issues with other mods expecting pages to be present.
+                        fake.putSubTag("pages", new NbtList());
                     }
 
                     return fake;

--- a/src/main/java/org/samo_lego/golfiv/event/S2CPacket/ItemInventoryKickPatch.java
+++ b/src/main/java/org/samo_lego/golfiv/event/S2CPacket/ItemInventoryKickPatch.java
@@ -1,14 +1,20 @@
 package org.samo_lego.golfiv.event.S2CPacket;
 
 import io.netty.buffer.Unpooled;
-import net.minecraft.item.ItemStack;
+import net.minecraft.block.Block;
+import net.minecraft.block.ShulkerBoxBlock;
+import net.minecraft.item.*;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtList;
 import net.minecraft.network.Packet;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.InventoryS2CPacket;
 import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
 import org.samo_lego.golfiv.mixin.accessors.InventoryS2CPacketAccessor;
 import org.samo_lego.golfiv.mixin.accessors.ScreenHandlerSlotUpdateS2CPacketAccessor;
 
@@ -38,7 +44,132 @@ public class ItemInventoryKickPatch implements S2CPacketCallback {
             List<ItemStack> fakedContents = contents.stream().map(stack -> {
                 NbtCompound tag = stack.getTag();
                 if(tag != null) {
-                    stack = fakeStack(stack, false);
+                    // TODO: Perhaps take a more dynamic approach to this?
+                    //  This is not really flexible as is and may leave modded items broken.
+                    Item item = stack.getItem();
+                    ItemStack fake = new ItemStack(item, stack.getCount());
+
+                    // Rewrite display.
+                    if(tag.contains(ItemStack.DISPLAY_KEY)) {
+                        NbtCompound display = tag.getCompound(ItemStack.DISPLAY_KEY);
+                        NbtCompound fakeDisplay = new NbtCompound();
+                        NbtElement name = display.get(ItemStack.NAME_KEY);
+                        if(name != null) fakeDisplay.put(ItemStack.NAME_KEY, name);
+                        if(display.contains(ItemStack.COLOR_KEY)) fakeDisplay.put(ItemStack.COLOR_KEY, display.get(ItemStack.COLOR_KEY));
+                        NbtElement lore = display.get(ItemStack.LORE_KEY);
+                        if(lore != null) fakeDisplay.put(ItemStack.LORE_KEY, lore);
+                        fake.putSubTag(ItemStack.DISPLAY_KEY, fakeDisplay);
+                    }
+
+                    // Rewrite enchantments.
+                    if(stack.hasEnchantments()) {
+                        NbtList enchants = new NbtList();
+                        for(NbtElement enchant : stack.getEnchantments()) {
+                            if(enchant instanceof NbtCompound) {
+                                NbtCompound compound = (NbtCompound) enchant;
+                                String id = compound.getString(ItemStack.ID_KEY);
+                                int lvl = compound.getInt(ItemStack.LVL_KEY);
+                                if(Registry.ENCHANTMENT.containsId(new Identifier(id))) {
+                                    NbtCompound minimalEnchant = new NbtCompound();
+                                    minimalEnchant.putString(ItemStack.ID_KEY, id);
+                                    minimalEnchant.putInt(ItemStack.LVL_KEY, lvl);
+                                    enchants.add(minimalEnchant);
+                                }
+                            }
+                        }
+                        fake.putSubTag(ItemStack.ENCHANTMENTS_KEY, enchants);
+                    }
+
+                    // Rewrite damage if it is damageable.
+                    if(stack.isDamageable()) {
+                        fake.setDamage(stack.getDamage());
+                    }
+
+                    // Check block items.
+                    if(item instanceof BlockItem) {
+                        boolean flag = true;
+                        if(item instanceof BannerItem) {
+                            flag = false;
+                            NbtCompound blockEntity = stack.getSubTag("BlockEntityTag");
+                            if (blockEntity != null && blockEntity.contains("Patterns", NbtElement.LIST_TYPE)) {
+                                NbtList fakePatterns = new NbtList();
+                                for(NbtElement pattern : blockEntity.getList("Patterns", NbtElement.COMPOUND_TYPE)) {
+                                    if(!(pattern instanceof NbtCompound)) continue;
+                                    NbtCompound oldPattern = (NbtCompound) pattern;
+                                    if (oldPattern.contains("Color", NbtElement.INT_TYPE) &&
+                                            oldPattern.contains("Pattern", NbtElement.STRING_TYPE)) {
+                                        if(oldPattern.getSize() == 2) {
+                                            fakePatterns.add(oldPattern);
+                                        } else {
+                                            NbtCompound fakePattern = new NbtCompound();
+                                            fakePattern.put("Color", oldPattern.get("Color"));
+                                            fakePattern.put("Pattern", oldPattern.get("Pattern"));
+                                            fakePatterns.add(fakePattern);
+                                        }
+                                    }
+                                }
+                                fake.getOrCreateSubTag("BlockEntityTag").put("Patterns", fakePatterns);
+                            }
+                        }
+
+                        if(flag) {
+                            Block block = ((BlockItem) item).getBlock();
+
+                            // Rewrite shulker items
+                            if (block instanceof ShulkerBoxBlock) {
+                                NbtCompound blockEntity = stack.getSubTag("BlockEntityTag");
+                                if(blockEntity != null) {
+                                    NbtCompound fakeEntity = fake.getOrCreateSubTag("BlockEntityTag");
+                                    if(blockEntity.contains("LootTable", NbtElement.STRING_TYPE)) {
+                                        fakeEntity.put("LootTable", blockEntity.get("LootTable"));
+                                    }
+                                    if(blockEntity.contains("Items", NbtElement.LIST_TYPE)) {
+                                        NbtList fakeItems = new NbtList();
+                                        for(NbtElement $item : blockEntity.getList("Items", NbtElement.COMPOUND_TYPE)) {
+                                            if($item == null) continue;
+                                            NbtCompound oldItem = (NbtCompound) $item;
+                                            NbtCompound fakeItem = new NbtCompound();
+                                            if(oldItem.contains("Slot", NbtElement.BYTE_TYPE)) fakeItem.put("Slot", oldItem.get("Slot"));
+                                            if(oldItem.contains("id", NbtElement.STRING_TYPE)) fakeItem.put("id", oldItem.get("id"));
+                                            if(oldItem.contains("Count", NbtElement.BYTE_TYPE)) fakeItem.put("Count", oldItem.get("Count"));
+                                            // TODO: Add in display name
+                                            fakeItems.add(fakeItem);
+                                        }
+                                        fakeEntity.put("Items", fakeItems);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Rewrite potion effects.
+                    if(item instanceof PotionItem || item instanceof TippedArrowItem) {
+                        if(tag.contains("Potion", NbtElement.STRING_TYPE)) fake.putSubTag("Potion", tag.get("Potion"));
+                        if(tag.contains("CustomPotionColor", NbtElement.INT_TYPE)) fake.putSubTag("CustomPotionColor", tag.get("CustomPotionColor"));
+                        if(tag.contains("CustomPotionEffects", NbtElement.LIST_TYPE)) {
+                            NbtList fakeEffects = new NbtList();
+                            for(NbtElement effect : tag.getList("CustomPotionEffects", NbtElement.COMPOUND_TYPE)) {
+                                if(effect == null) continue;
+                                NbtCompound oldEffect = (NbtCompound) effect;
+                                NbtCompound fakeEffect = new NbtCompound();
+                                if(oldEffect.contains("Id", NbtElement.STRING_TYPE)) fakeEffect.put("Id", oldEffect.get("Id"));
+                                if(oldEffect.contains("Amplifier", NbtElement.BYTE_TYPE)) fakeEffect.put("Amplifier", oldEffect.get("Amplifier"));
+                                if(oldEffect.contains("Duration", NbtElement.INT_TYPE)) fakeEffect.put("Duration", oldEffect.get("Duration"));
+                                fakeEffects.add(fakeEffect);
+                            }
+                            fake.putSubTag("CustomPotionEffects", fakeEffects);
+                        }
+                    }
+
+                    // Brokenly rewrites written books.
+                    if(item instanceof WrittenBookItem) {
+                        if(tag.contains("title", NbtElement.STRING_TYPE)) fake.putSubTag("title", tag.get("title"));
+                        if(tag.contains("author", NbtElement.STRING_TYPE)) fake.putSubTag("author", tag.get("author"));
+                        if(tag.contains("generation", NbtElement.INT_TYPE)) fake.putSubTag("generation", tag.get("generation"));
+                        // FIXME: Pages need to be present for the book to work. Force update on selection?
+                    }
+
+                    return fake;
                 }
 
                 return stack;
@@ -52,6 +183,7 @@ public class ItemInventoryKickPatch implements S2CPacketCallback {
                 if(testBuf.writeItemStack(stack).readableBytes() > 2097140) {
                     ((ScreenHandlerSlotUpdateS2CPacketAccessor) packet).setStack(fakeStack(stack, false));
                 }
+                testBuf.release();
             }
         }
     }

--- a/src/main/java/org/samo_lego/golfiv/event/S2CPacket/ItemInventoryKickPatch.java
+++ b/src/main/java/org/samo_lego/golfiv/event/S2CPacket/ItemInventoryKickPatch.java
@@ -1,20 +1,14 @@
 package org.samo_lego.golfiv.event.S2CPacket;
 
 import io.netty.buffer.Unpooled;
-import net.minecraft.block.Block;
-import net.minecraft.block.ShulkerBoxBlock;
-import net.minecraft.item.*;
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
-import net.minecraft.nbt.NbtElement;
-import net.minecraft.nbt.NbtList;
 import net.minecraft.network.Packet;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.InventoryS2CPacket;
 import net.minecraft.network.packet.s2c.play.ScreenHandlerSlotUpdateS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.registry.Registry;
 import org.samo_lego.golfiv.mixin.accessors.InventoryS2CPacketAccessor;
 import org.samo_lego.golfiv.mixin.accessors.ScreenHandlerSlotUpdateS2CPacketAccessor;
 
@@ -23,6 +17,7 @@ import java.util.stream.Collectors;
 
 import static org.samo_lego.golfiv.GolfIV.golfConfig;
 import static org.samo_lego.golfiv.casts.ItemStackChecker.fakeStack;
+import static org.samo_lego.golfiv.casts.ItemStackChecker.inventoryStack;
 
 public class ItemInventoryKickPatch implements S2CPacketCallback {
 
@@ -44,140 +39,7 @@ public class ItemInventoryKickPatch implements S2CPacketCallback {
             List<ItemStack> fakedContents = contents.stream().map(stack -> {
                 NbtCompound tag = stack.getTag();
                 if(tag != null) {
-                    // TODO: Perhaps take a more dynamic approach to this?
-                    //  This is not really flexible as is and may leave modded items broken.
-                    Item item = stack.getItem();
-                    ItemStack fake = new ItemStack(item, stack.getCount());
-
-                    // Rewrite display.
-                    if(tag.contains(ItemStack.DISPLAY_KEY)) {
-                        NbtCompound display = tag.getCompound(ItemStack.DISPLAY_KEY);
-                        NbtCompound fakeDisplay = new NbtCompound();
-                        NbtElement name = display.get(ItemStack.NAME_KEY);
-                        if(name != null) fakeDisplay.put(ItemStack.NAME_KEY, name);
-                        if(display.contains(ItemStack.COLOR_KEY)) fakeDisplay.put(ItemStack.COLOR_KEY, display.get(ItemStack.COLOR_KEY));
-                        NbtElement lore = display.get(ItemStack.LORE_KEY);
-                        if(lore != null) fakeDisplay.put(ItemStack.LORE_KEY, lore);
-                        fake.putSubTag(ItemStack.DISPLAY_KEY, fakeDisplay);
-                    }
-
-                    // Rewrite enchantments.
-                    if(stack.hasEnchantments()) {
-                        NbtList enchants = new NbtList();
-                        for(NbtElement enchant : stack.getEnchantments()) {
-                            if(enchant instanceof NbtCompound) {
-                                NbtCompound compound = (NbtCompound) enchant;
-                                String id = compound.getString(ItemStack.ID_KEY);
-                                int lvl = compound.getInt(ItemStack.LVL_KEY);
-                                if(Registry.ENCHANTMENT.containsId(new Identifier(id))) {
-                                    NbtCompound minimalEnchant = new NbtCompound();
-                                    minimalEnchant.putString(ItemStack.ID_KEY, id);
-                                    minimalEnchant.putInt(ItemStack.LVL_KEY, lvl);
-                                    enchants.add(minimalEnchant);
-                                }
-                            }
-                        }
-                        fake.putSubTag(ItemStack.ENCHANTMENTS_KEY, enchants);
-                    }
-
-                    // Rewrite damage if it is damageable.
-                    if(stack.isDamageable()) {
-                        fake.setDamage(stack.getDamage());
-                    }
-
-                    // Check block items.
-                    if(item instanceof BlockItem) {
-                        boolean flag = true;
-                        if(item instanceof BannerItem) {
-                            flag = false;
-                            NbtCompound blockEntity = stack.getSubTag("BlockEntityTag");
-                            if (blockEntity != null && blockEntity.contains("Patterns", NbtElement.LIST_TYPE)) {
-                                NbtList fakePatterns = new NbtList();
-                                for(NbtElement pattern : blockEntity.getList("Patterns", NbtElement.COMPOUND_TYPE)) {
-                                    if(!(pattern instanceof NbtCompound)) continue;
-                                    NbtCompound oldPattern = (NbtCompound) pattern;
-                                    if (oldPattern.contains("Color", NbtElement.INT_TYPE) &&
-                                            oldPattern.contains("Pattern", NbtElement.STRING_TYPE)) {
-                                        if(oldPattern.getSize() == 2) {
-                                            fakePatterns.add(oldPattern);
-                                        } else {
-                                            NbtCompound fakePattern = new NbtCompound();
-                                            fakePattern.put("Color", oldPattern.get("Color"));
-                                            fakePattern.put("Pattern", oldPattern.get("Pattern"));
-                                            fakePatterns.add(fakePattern);
-                                        }
-                                    }
-                                }
-                                fake.getOrCreateSubTag("BlockEntityTag").put("Patterns", fakePatterns);
-                            }
-                        }
-
-                        if(flag) {
-                            Block block = ((BlockItem) item).getBlock();
-
-                            // Rewrite shulker items
-                            if (block instanceof ShulkerBoxBlock) {
-                                NbtCompound blockEntity = stack.getSubTag("BlockEntityTag");
-                                if(blockEntity != null) {
-                                    NbtCompound fakeEntity = fake.getOrCreateSubTag("BlockEntityTag");
-                                    if(blockEntity.contains("LootTable", NbtElement.STRING_TYPE)) {
-                                        fakeEntity.put("LootTable", blockEntity.get("LootTable"));
-                                    }
-                                    if(blockEntity.contains("Items", NbtElement.LIST_TYPE)) {
-                                        NbtList fakeItems = new NbtList();
-                                        for(NbtElement $item : blockEntity.getList("Items", NbtElement.COMPOUND_TYPE)) {
-                                            if($item == null) continue;
-                                            NbtCompound oldItem = (NbtCompound) $item;
-                                            NbtCompound fakeItem = new NbtCompound();
-                                            if(oldItem.contains("Slot", NbtElement.BYTE_TYPE)) fakeItem.put("Slot", oldItem.get("Slot"));
-                                            if(oldItem.contains("id", NbtElement.STRING_TYPE)) fakeItem.put("id", oldItem.get("id"));
-                                            if(oldItem.contains("Count", NbtElement.BYTE_TYPE)) fakeItem.put("Count", oldItem.get("Count"));
-                                            // TODO: Add in display name
-                                            fakeItems.add(fakeItem);
-                                        }
-                                        fakeEntity.put("Items", fakeItems);
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    // Rewrite potion effects.
-                    if(item instanceof PotionItem || item instanceof TippedArrowItem) {
-                        if(tag.contains("Potion", NbtElement.STRING_TYPE)) fake.putSubTag("Potion", tag.get("Potion"));
-                        if(tag.contains("CustomPotionColor", NbtElement.INT_TYPE)) fake.putSubTag("CustomPotionColor", tag.get("CustomPotionColor"));
-                        if(tag.contains("CustomPotionEffects", NbtElement.LIST_TYPE)) {
-                            NbtList fakeEffects = new NbtList();
-                            for(NbtElement effect : tag.getList("CustomPotionEffects", NbtElement.COMPOUND_TYPE)) {
-                                if(effect == null) continue;
-                                NbtCompound oldEffect = (NbtCompound) effect;
-                                NbtCompound fakeEffect = new NbtCompound();
-                                if(oldEffect.contains("Id", NbtElement.STRING_TYPE)) fakeEffect.put("Id", oldEffect.get("Id"));
-                                if(oldEffect.contains("Amplifier", NbtElement.BYTE_TYPE)) fakeEffect.put("Amplifier", oldEffect.get("Amplifier"));
-                                if(oldEffect.contains("Duration", NbtElement.INT_TYPE)) fakeEffect.put("Duration", oldEffect.get("Duration"));
-                                fakeEffects.add(fakeEffect);
-                            }
-                            fake.putSubTag("CustomPotionEffects", fakeEffects);
-                        }
-                    }
-
-                    // Brokenly rewrites written books.
-                    if(item instanceof WrittenBookItem) {
-                        if(tag.contains("title", NbtElement.STRING_TYPE)) fake.putSubTag("title", tag.get("title"));
-                        if(tag.contains("author", NbtElement.STRING_TYPE)) fake.putSubTag("author", tag.get("author"));
-                        if(tag.contains("generation", NbtElement.INT_TYPE)) fake.putSubTag("generation", tag.get("generation"));
-                        // FIXME: Pages need to be present for the book to work. Force update on selection?
-                        // Prevents issues with other mods expecting pages to be present.
-                        fake.putSubTag("pages", new NbtList());
-                    }
-
-                    if(item instanceof WritableBookItem) {
-                        // FIXME: Pages need to be present for the book to work. Force update on selection?
-                        // Prevents issues with other mods expecting pages to be present.
-                        fake.putSubTag("pages", new NbtList());
-                    }
-
-                    return fake;
+                    return inventoryStack(stack);
                 }
 
                 return stack;

--- a/src/main/java/org/samo_lego/golfiv/mixin/accessors/LivingEntityAccessor.java
+++ b/src/main/java/org/samo_lego/golfiv/mixin/accessors/LivingEntityAccessor.java
@@ -1,0 +1,18 @@
+package org.samo_lego.golfiv.mixin.accessors;// Created 2021-30-06T00:07:26
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.data.TrackedData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * @author KJP12
+ * @since ${version}
+ **/
+@Mixin(LivingEntity.class)
+public interface LivingEntityAccessor {
+    @Accessor("HEALTH")
+    static TrackedData<Float> getHealth() {
+        throw new AssertionError("Accessor failed.");
+    }
+}

--- a/src/main/java/org/samo_lego/golfiv/mixin/accessors/PlayerEntityAccessor.java
+++ b/src/main/java/org/samo_lego/golfiv/mixin/accessors/PlayerEntityAccessor.java
@@ -1,0 +1,18 @@
+package org.samo_lego.golfiv.mixin.accessors;// Created 2021-30-06T00:10:45
+
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+/**
+ * @author KJP12
+ * @since ${version}
+ **/
+@Mixin(PlayerEntity.class)
+public interface PlayerEntityAccessor {
+    @Accessor("ABSORPTION_AMOUNT")
+    static TrackedData<Float> getAbsorption() {
+        throw new AssertionError("Accessor failed.");
+    }
+}

--- a/src/main/resources/golfiv.mixins.json
+++ b/src/main/resources/golfiv.mixins.json
@@ -12,6 +12,8 @@
     "accessors.EntityTrackerUpdateS2CPacketAccessor",
     "accessors.InventoryS2CPacketAccessor",
     "accessors.ItemEntityAccessor",
+    "accessors.LivingEntityAccessor",
+    "accessors.PlayerEntityAccessor",
     "accessors.PlayerMoveC2SPacketAccessor",
     "accessors.PlaySoundS2CPacketAccessor",
     "accessors.ScreenHandlerSlotUpdateS2CPacketAccessor",


### PR DESCRIPTION
This PR aims to fix insufficient NBT being passed for various items at various states, and to also efficiently remove unnecessary NBT in the event of the packet being a potential client kicker.

## Goals
- [x] A size check to tell if the packet would overflow.
   - Ideally, this would be efficient and only would have to write the data once. Although, this may fall out of scope for here.
   - [ ] Optional strict mode to always process the packet?
- [ ] Ideally be data-driven to allow for user or external mod configuration of what NBT should remain present on the item.
   - In this PR's current state, it's hard coded to some select vanilla NBT.
- [x] Fixes \<untracked\> *Potions and tipped arrows will appear as uncraftable variants when dropped.*
   - This replaces the potion data with only the potion color to obscure the actual potion.
   - However, the enchantment glint is still missing on the dropped potion. Doesn't apply to tipped arrows.
- [x] Fixes \<untracked\> *Banners will appear as just the base color when dropped.*
   - This needs an additional bound in case a banner was made with many more layers than normally supported. <=12 layers?
- [x] Fixes \<untracked\> *Dyed leather armor does not appear dyed.*
- [x] Fixes \<untracked\> *Maps do not show their data.*
- [x] Fixes \<untracked\> *Spyglass does not show when one is using it*
   - [x] Bonus fix: Health is now properly hidden again. Iron golems and withers now properly render their health and stage as they have a special exception of every quarter health.
- [x] Fixes #39
   - [x] Completely unhides the inventory. This PR in its current state does not keep the NBT properly unhidden when it isn't necessary.
   - [x] Works with illegal item clearing.
   - [x] Works with armor being equipped.
- [x] Fixes KJP12#2 *Tool damage desync* - This PR completely fixes this issue in its current state.
   - [x] Works with opening inventories other than the player inventory.
   - [x] Works with relogging.
- [x] Fixes KJP12#6 *Missing `pages` tag crashing other mods* - This PR should fix this issue in its current state. This is primarily preventive as the breaking mod has already been patched to account for the broken data.
   - [x] Works with Server Translations 1.4.2, the version that originally conflicted, in the development environment.