### PR TITLE
Potion patches & data tracker fixing.

### DIFF
--- a/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
+++ b/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
@@ -2,6 +2,8 @@ package org.samo_lego.golfiv.casts;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.ShulkerBoxBlock;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
@@ -10,10 +12,18 @@ import net.minecraft.potion.PotionUtil;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * Checks iItemStacks.
  */
 public interface ItemStackChecker {
+    /**
+     * Cached unluck singleton
+     */
+    Collection<StatusEffectInstance> UNLUCK = Collections.singleton(new StatusEffectInstance(StatusEffects.UNLUCK, 6000));
+
     /**
      * Checks the ItemStack and makes it legal.
      * Removes all enchantments if they are incompatible or
@@ -51,6 +61,9 @@ public interface ItemStackChecker {
         if(item instanceof PotionItem || item instanceof TippedArrowItem) {
             // Lets dropping potions and arrows to be less of a 'surprising' change.
             fakedStack.getOrCreateTag().putInt("CustomPotionColor", PotionUtil.getColor(original));
+            if (item.hasGlint(original)) {
+                PotionUtil.setCustomPotionEffects(fakedStack, UNLUCK);
+            }
         }
 
         if(item instanceof WritableBookItem || item instanceof WrittenBookItem) {

--- a/src/main/java/org/samo_lego/golfiv/mixin/illegal_items/ItemStackMixinCast_ItemStackChecker.java
+++ b/src/main/java/org/samo_lego/golfiv/mixin/illegal_items/ItemStackMixinCast_ItemStackChecker.java
@@ -75,7 +75,7 @@ public abstract class ItemStackMixinCast_ItemStackChecker implements ItemStackCh
                     this.itemStack.getItem() == Items.LINGERING_POTION
                 )
         ) {
-            List<StatusEffectInstance> effects = PotionUtil.getPotionEffects(this.itemStack);
+            List<StatusEffectInstance> effects = PotionUtil.getCustomPotionEffects(this.itemStack);
             for(StatusEffectInstance effect : effects) {
                 if(effect.getAmplifier() > 1) {
                     this.removeSubTag("CustomPotionEffects");

--- a/src/main/java/org/samo_lego/golfiv/mixin/packets/EntityTrackerUpdateS2CPacketMixin_DataPatch.java
+++ b/src/main/java/org/samo_lego/golfiv/mixin/packets/EntityTrackerUpdateS2CPacketMixin_DataPatch.java
@@ -54,8 +54,8 @@ public class EntityTrackerUpdateS2CPacketMixin_DataPatch {
         Entity entity = ((DataTrackerAccessor) tracker).getTrackedEntity();
 
         if (golfConfig.packet.removeHealthTags && entity instanceof LivingEntity && entity.isAlive() && !(entity instanceof Saddleable)) {
-            trackedValues.removeIf(trackedValue -> trackedValue.getData().equals(LIVING_ENTITY_HEALTH));
-            trackedValues.removeIf(trackedValue -> trackedValue.getData().equals(PLAYER_ENTITY_ABSORPTION));
+            trackedValues.removeIf(trackedValue -> trackedValue.getData() == LIVING_ENTITY_HEALTH);
+            trackedValues.removeIf(trackedValue -> trackedValue.getData() == PLAYER_ENTITY_ABSORPTION);
 
             if (entity instanceof IronGolemEntity || entity instanceof WitherEntity) {
                 // Reinjects the health data aligned to quarters.
@@ -70,7 +70,7 @@ public class EntityTrackerUpdateS2CPacketMixin_DataPatch {
                 trackedValues.add(fakeEntry);
             }
         } else if (golfConfig.packet.removeDroppedItemInfo && entity instanceof ItemEntity) {
-            boolean removed = trackedValues.removeIf(entry -> entry.getData().equals(ITEM_ENTITY_STACK)); // Original item
+            boolean removed = trackedValues.removeIf(entry -> entry.getData() == ITEM_ENTITY_STACK); // Original item
             if (removed) {
                 ItemStack original = ((ItemEntity) entity).getStack();
 


### PR DESCRIPTION
- Fixes data tracker patch clearing wrong data on some entities. An equality check is used instead.
- Fixes #40
  Only custom effects are checked now. Effects provided by potion are usually intended by either vanilla or mods.
- Fixes #47
  Potion data is replaced with bad luck to obscure the actual potion if a glint is supposed to be present.