### PR TITLE
Fixes for textured heads & creative inventories

### DIFF
--- a/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
+++ b/src/main/java/org/samo_lego/golfiv/casts/ItemStackChecker.java
@@ -7,6 +7,7 @@ import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
+import net.minecraft.nbt.NbtInt;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.potion.PotionUtil;
 import net.minecraft.util.Identifier;
@@ -81,6 +82,23 @@ public interface ItemStackChecker {
         }
 
         return fakedStack;
+    }
+
+    /**
+     * This is for keeping creative from getting inadvertently sanitised,
+     * as creative has the property of allowing one to summon any item at will,
+     * including freely mutating the inventory.
+     *
+     * @param stack The original ItemStack.
+     * @return The faked ItemStack, with a GolfIV pointer injected.
+     * @author KJP12
+     * @see #inventoryStack(ItemStack)
+     */
+    static ItemStack creativeInventoryStack(ItemStack stack) {
+        ItemStack fake = inventoryStack(stack);
+        if (stack.hasNbt()) //noinspection ConstantConditions
+            fake.setSubNbt("GolfIV", NbtInt.of(stack.getNbt().hashCode()));
+        return fake;
     }
 
     /**

--- a/src/main/java/org/samo_lego/golfiv/event/S2CPacket/ItemInventoryKickPatch.java
+++ b/src/main/java/org/samo_lego/golfiv/event/S2CPacket/ItemInventoryKickPatch.java
@@ -13,10 +13,11 @@ import org.samo_lego.golfiv.mixin.accessors.InventoryS2CPacketAccessor;
 import org.samo_lego.golfiv.mixin.accessors.ScreenHandlerSlotUpdateS2CPacketAccessor;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.function.Consumer;
 
 import static org.samo_lego.golfiv.GolfIV.golfConfig;
-import static org.samo_lego.golfiv.casts.ItemStackChecker.fakeStack;
+import static org.samo_lego.golfiv.casts.ItemStackChecker.creativeInventoryStack;
+import static org.samo_lego.golfiv.casts.ItemStackChecker.inventoryStack;
 
 public class ItemInventoryKickPatch implements S2CPacketCallback {
 
@@ -24,34 +25,63 @@ public class ItemInventoryKickPatch implements S2CPacketCallback {
     }
 
     /**
-     * Changes ItemStacks in {@link InventoryS2CPacket}
-     * to not include tags, as they get sent additionally by {@link ScreenHandlerSlotUpdateS2CPacket}
+     * Removes non-critical tags from item stacks in the event of a
+     * creative player and packet overflows.
+     * <p>
+     * Creative players will additionally also get a {@code GolfIV} tag
+     * injected as a hash of the original NBT to prevent Creative inventory
+     * management from unexpectedly mangling the item either by just opening
+     * the inventory or by {@link org.samo_lego.golfiv.storage.GolfConfig.IllegalItems.Creative#removeCreativeNBTTags
+     * Remove Creative NBT Tags}.
      *
      * @param packet packet being sent
      * @param player player getting the packet
      * @param server Minecraft Server
+     * @see ItemStackChecker#fakeStack(ItemStack, boolean)
+     * @see ItemStackChecker#inventoryStack(ItemStack)
+     * @see org.samo_lego.golfiv.mixin.illegal_items.ServerPlayNetworkHandlerMixin_CreativeItemsCheck
      */
     @Override
     public void preSendPacket(Packet<?> packet, ServerPlayerEntity player, MinecraftServer server) {
-        if(golfConfig.packet.patchItemKickExploit && packet instanceof InventoryS2CPacket) {
-            PacketByteBuf testBuf = new PacketByteBuf(Unpooled.buffer());
-            packet.write(testBuf);
-            if(testBuf.readableBytes() > 2097140) {
-                List<ItemStack> contents = ((InventoryS2CPacketAccessor) packet).getContents();
-                List<ItemStack> fakedContents = contents.stream().map(ItemStackChecker::inventoryStack).collect(Collectors.toList());
+        if (!golfConfig.packet.patchItemKickExploit) return;
+        if (packet instanceof InventoryS2CPacket inventoryPacket) {
+            // The creative player does some weirdness in regards to sending packets.
+            // This will try to guarantee that the creative player will not accidentally
+            // wipe their inventory of various NBT required for the item.
+
+            // For the moment, this may produce some weirdness in regards to rendering as this doesn't quite
+            // send all possible NBT. However, the inventory will remain intact, which arguably is better
+            // than some missing data for the client.
+            if (player.isCreative() || isOversized(packet::write)) {
+                List<ItemStack> contents = inventoryPacket.getContents();
+                List<ItemStack> fakedContents = contents.stream().map(player.isCreative() ?
+                                ItemStackChecker::creativeInventoryStack :
+                                ItemStackChecker::inventoryStack)
+                        .toList();
 
                 ((InventoryS2CPacketAccessor) packet).setContents(fakedContents);
             }
-            testBuf.release();
-        } else if(golfConfig.packet.patchItemKickExploit && packet instanceof ScreenHandlerSlotUpdateS2CPacket) {
+        } else if (packet instanceof ScreenHandlerSlotUpdateS2CPacket) {
             ItemStack stack = ((ScreenHandlerSlotUpdateS2CPacketAccessor) packet).getStack();
-            if(stack.getNbt() != null) {
-                PacketByteBuf testBuf = new PacketByteBuf(Unpooled.buffer());
-                if(testBuf.writeItemStack(stack).readableBytes() > 2097140) {
-                    ((ScreenHandlerSlotUpdateS2CPacketAccessor) packet).setStack(fakeStack(stack, false));
-                }
-                testBuf.release();
+            if (stack.hasNbt() && (player.isCreative() || isOversized(buf -> buf.writeItemStack(stack)))) {
+                ((ScreenHandlerSlotUpdateS2CPacketAccessor) packet).setStack(player.isCreative() ? creativeInventoryStack(stack) : inventoryStack(stack));
             }
+        }
+    }
+
+    /**
+     * Tests if the packet will overflow the maximum allowed for the buffer.
+     *
+     * @param packet The packet in the form of a consumer. Allows for arbitrary packets.
+     * @return true if the packet is greater than 2,097,140, false otherwise.
+     */
+    private static boolean isOversized(Consumer<PacketByteBuf> packet) {
+        PacketByteBuf testBuf = new PacketByteBuf(Unpooled.buffer());
+        try {
+            packet.accept(testBuf);
+            return testBuf.readableBytes() > 2097140;
+        } finally {
+            testBuf.release();
         }
     }
 }

--- a/src/main/java/org/samo_lego/golfiv/mixin/illegal_items/ServerPlayNetworkHandlerMixin_CreativeItemsCheck.java
+++ b/src/main/java/org/samo_lego/golfiv/mixin/illegal_items/ServerPlayNetworkHandlerMixin_CreativeItemsCheck.java
@@ -1,26 +1,60 @@
 package org.samo_lego.golfiv.mixin.illegal_items;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.network.Packet;
+import net.minecraft.network.listener.PacketListener;
+import net.minecraft.network.packet.c2s.play.CloseHandledScreenC2SPacket;
+import net.minecraft.screen.slot.Slot;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import org.samo_lego.golfiv.casts.ItemStackChecker;
+import org.samo_lego.golfiv.storage.GolfConfig;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import static org.samo_lego.golfiv.GolfIV.golfConfig;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public abstract class ServerPlayNetworkHandlerMixin_CreativeItemsCheck {
-    @Shadow public ServerPlayerEntity player;
+    @Unique
+    private final Int2ObjectMap<NbtCompound> nbtMap = new Int2ObjectOpenHashMap<>();
+    private boolean nbtMapPopulated = false;
+
+    @Shadow
+    public ServerPlayerEntity player;
 
     /**
-     * Clears the CompoundTags from creative items while still allowing pick block function
+     * Recovers stack NBT and clears illegal tags from creative items while still allowing pick block function.
+     * <p>
+     * If {@link GolfConfig.Packet#patchItemKickExploit Patch Item Kick Exploit} is enabled and the tag {@code GolfIV}
+     * is present, the hash is looked up in {@link #nbtMap} to recover the original NBT of the item, and allowing
+     * bypass of {@link GolfConfig.IllegalItems.Creative#removeCreativeNBTTags Remove Creative NBT Tags}.
+     * <p>
+     * If {@link GolfConfig.IllegalItems.Creative#removeCreativeNBTTags Remove Creative NBT Tags} is enabled,
+     * and the tag {@code GolfIV} was not found or invalid, then the items are sanitised in accordance to the
+     * set {@link GolfConfig.IllegalItems.Creative#whitelistedNBT Whitelisted NBT} in the config.
      *
-     * @param itemStack ItemStack to be checked
-     * @return "sanitized" ItemStack
+     * @param itemStack The stack to either recover the NBT by hash from, or to be sanitized.
+     * @return Recovered stack if GolfIV hash tag is present and valid, "sanitized" stack otherwise.
+     * @author samo_lego
+     * @author KJP12
+     * @see ItemStackChecker#fakeStack(ItemStack, boolean)
+     * @see org.samo_lego.golfiv.event.S2CPacket.ItemInventoryKickPatch
+     * @see GolfConfig.Packet#patchItemKickExploit
+     * @see GolfConfig.IllegalItems.Creative#removeCreativeNBTTags
+     * @see GolfConfig.IllegalItems.Creative#whitelistedNBT
      */
     @ModifyVariable(
             method = "onCreativeInventoryAction(Lnet/minecraft/network/packet/c2s/play/CreativeInventoryActionC2SPacket;)V",
@@ -30,20 +64,147 @@ public abstract class ServerPlayNetworkHandlerMixin_CreativeItemsCheck {
             )
     )
     private ItemStack checkCreativeItem(ItemStack itemStack) {
-        if(golfConfig.items.creative.removeCreativeNBTTags) {
+        if (!itemStack.isEmpty()) {
             NbtCompound compoundTag = itemStack.getNbt();
-            NbtCompound newData = new NbtCompound();
-            if(compoundTag != null) {
-                golfConfig.items.creative.whitelistedNBT.forEach(tag -> {
-                    if(compoundTag.contains(tag)) {
-                        newData.put(tag, compoundTag.get(tag));
+            checkTag:
+            if (compoundTag != null && !compoundTag.isEmpty()) {
+                // In the case of the GolfIV tag, the NBT will be determined by the hash.
+                // Since the hash usually means it already exists in the inventory, we can
+                // assume that it's either been given by OP, or already existed before.
+                // We will check to see if patchItemKickExploit is enabled before continuing however.
+                if (golfConfig.packet.patchItemKickExploit && compoundTag.contains("GolfIV", NbtElement.INT_TYPE)) {
+                    int mapHash = compoundTag.getInt("GolfIV");
+                    if (!nbtMapPopulated && !nbtMap.containsKey(mapHash)) {
+                        // If this gets called, it means that the player cloned it via middle-click.
+                        // Instead of falling back to the sanitiser, we should make sure it isn't
+                        // already in the inventory as something else.
+                        populateNbtMap();
                     }
-                });
+                    NbtCompound newNbt = nbtMap.get(mapHash);
+                    if (newNbt != null) {
+                        itemStack.setNbt(newNbt.copy());
+                        break checkTag;
+                    }
+                    compoundTag.remove("GolfIV");
+                }
+                if (golfConfig.items.creative.removeCreativeNBTTags) {
+                    NbtCompound newData = new NbtCompound();
+                    golfConfig.items.creative.whitelistedNBT.forEach(tag -> {
+                        if (compoundTag.contains(tag)) {
+                            newData.put(tag, compoundTag.get(tag));
+                        }
+                    });
+                    itemStack.setNbt(newData);
+                    //noinspection ConstantConditions
+                    ((ItemStackChecker) (Object) itemStack).makeLegal(false);
+                }
             }
-            itemStack.setNbt(newData);
-            //noinspection ConstantConditions
-            ((ItemStackChecker) (Object) itemStack).makeLegal(false);
         }
         return itemStack;
+    }
+
+    /**
+     * Slowly populates {@link #nbtMap} to have a copy of good NBT for creative players.
+     * <p>
+     * If it's the same item being set, the hash is compared if it's present.
+     * If the hash matches the NBT, the NBT is stored and the count is set.
+     * <p>
+     * If it's not the same item, the hash of the old NBT is computed and
+     * stored for in case the creative player picked up or swapped the item.
+     * The new stack then is used to look up the NBT if the hash is set, and
+     * overwrites the NBT received from the creative player if present.
+     *
+     * @param self     The slot being mutated.
+     * @param newStack The item stack replacing the currently set stack.
+     * @implNote NBT is only checked and stored when {@link GolfConfig.Packet#patchItemKickExploit
+     * Patch Item Kick Exploit} is enabled.
+     * @author KJP12
+     * @see GolfConfig.Packet#patchItemKickExploit
+     */
+    @Redirect(
+            method = "onCreativeInventoryAction",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/screen/slot/Slot;setStack(Lnet/minecraft/item/ItemStack;)V")
+    )
+    private void onCreativeSetStack(Slot self, ItemStack newStack) {
+        // Check if patchItemKickExploit is enabled before continuing.
+        // As this can be costly, we should have an inexpensive check
+        // before the actual logic.
+        if (golfConfig.packet.patchItemKickExploit) {
+            ItemStack oldStack = self.getStack();
+
+            // If it's getting replaced, we cannot exactly verify if it's because the client
+            // decided to delete it or if it picked it up; the creative inventory works quite
+            // differently from every other inventory in that regard.
+            // This does allow for passive use before falling back to the more intensive method
+            // of populating the map manually.
+            if (!oldStack.isEmpty()) {
+                NbtCompound oldNbt = oldStack.getNbt();
+                if (oldNbt != null) {
+                    int hash = oldNbt.hashCode();
+                    NbtCompound mapNbt = nbtMap.get(hash);
+                    // TODO: This may ideally be a check to see if the hash is getting overwritten.
+                    //  It does seem unlikely this should actually happen normally tho.
+                    if (!oldNbt.equals(mapNbt)) {
+                        nbtMap.put(hash, oldNbt);
+                    }
+                }
+            }
+        }
+
+        self.setStack(newStack);
+    }
+
+    /**
+     * Clears {@link #nbtMap} when the current screen is closed.
+     * <p>
+     * This allows for the map to be reused, and prevents indefinite
+     * leaking for the session of the player.
+     * <p>
+     * The injection point is purposefully after {@link net.minecraft.network.NetworkThreadUtils#forceMainThread(Packet, PacketListener, ServerWorld)}
+     * to prevent asynchronous access of the map.
+     *
+     * @param packet Ignored by the method. Normally is to check sync ID.
+     * @param ci     Ignored by the method. Normally is to cancel the method or check its name.
+     * @implNote Despite being only relevant for {@link GolfConfig.Packet#patchItemKickExploit
+     * Patch Item Kick Exploit}, this method will always attempt to clear the map.
+     * @author KJP12
+     * @see GolfConfig.Packet#patchItemKickExploit
+     */
+    @Inject(method = "onCloseHandledScreen", at = @At(value = "INVOKE",
+            target = "Lnet/minecraft/network/NetworkThreadUtils;forceMainThread(Lnet/minecraft/network/Packet;Lnet/minecraft/network/listener/PacketListener;Lnet/minecraft/server/world/ServerWorld;)V",
+            shift = At.Shift.AFTER))
+    private void onCloseScreen(CloseHandledScreenC2SPacket packet, CallbackInfo ci) {
+        // Allows reuse and prevents indefinite leaking.
+        nbtMap.clear();
+        nbtMapPopulated = false;
+    }
+
+    /**
+     * Populates {@link #nbtMap} in the event that the client sends an
+     * unknown hash, usually by cloning via middle-click.
+     *
+     * @author KJP12
+     * @see #checkCreativeItem(ItemStack)
+     */
+    @Unique
+    private void populateNbtMap() {
+        PlayerInventory inventory = player.getInventory();
+        inventory.main.forEach(this::putNbt);
+        inventory.armor.forEach(this::putNbt);
+        inventory.offHand.forEach(this::putNbt);
+        nbtMapPopulated = true;
+    }
+
+    /**
+     * Method reference for mapping NBT to hashcode if not empty.
+     *
+     * @param stack The stack to copy and store the NBT of.
+     * @author KJP12
+     */
+    @Unique
+    private void putNbt(ItemStack stack) {
+        NbtCompound compound = stack.getNbt();
+        if (compound == null || compound.isEmpty()) return;
+        nbtMap.put(compound.hashCode(), compound.copy());
     }
 }

--- a/src/main/java/org/samo_lego/golfiv/mixin/packets/ServerPlayerEntityMixin_CreativeInventoryPatch.java
+++ b/src/main/java/org/samo_lego/golfiv/mixin/packets/ServerPlayerEntityMixin_CreativeInventoryPatch.java
@@ -1,0 +1,40 @@
+package org.samo_lego.golfiv.mixin.packets;// Created 2022-08-01T15:18:06
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.GameMode;
+import net.minecraft.world.World;
+import org.samo_lego.golfiv.GolfIV;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Injections to fix Creative in the case of a change in game mode.
+ *
+ * @author KJP12
+ **/
+@Mixin(ServerPlayerEntity.class)
+public abstract class ServerPlayerEntityMixin_CreativeInventoryPatch extends PlayerEntity {
+    public ServerPlayerEntityMixin_CreativeInventoryPatch(World world, BlockPos pos, float yaw, GameProfile profile) {
+        super(world, pos, yaw, profile);
+    }
+
+    /**
+     * Forcefully update the screen on game mode change to Creative.
+     *
+     * @param gameMode The new game mode.
+     * @param cir      Ignored; normally for returning something else.
+     * @reason Ensure that Creative doesn't accidentally nuke its own inventory.
+     * @author KJP12
+     */
+    @Inject(method = "changeGameMode", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;sendPacket(Lnet/minecraft/network/Packet;)V"))
+    private void onChangeGameMode(GameMode gameMode, CallbackInfoReturnable<Boolean> cir) {
+        if (GolfIV.golfConfig.packet.patchItemKickExploit && gameMode.isCreative()) {
+            currentScreenHandler.syncState();
+        }
+    }
+}

--- a/src/main/resources/golfiv.mixins.json
+++ b/src/main/resources/golfiv.mixins.json
@@ -30,6 +30,7 @@
     "illegal_items.ServerPlayNetworkHandlerMixin_IllegalsCheckSlot",
     "movement.ServerPlayNetworkHandler_OnGroundCheck",
     "packets.EntityTrackerUpdateS2CPacketMixin_DataPatch",
+    "packets.ServerPlayerEntityMixin_CreativeInventoryPatch",
     "packets.ServerPlayNetworkHandlerMixin_PacketEvents"
   ],
   "injectors": {


### PR DESCRIPTION
- Adds a `GolfIV` tag on items while in creative.
  - To ensure that all creative players get this tag...
    - The inventory is resent every time they switch to creative.
    - The inventory is always minimised and treated as overflown when in creative.
      - This does mean that items in creative maybe lacking NBT on the client, and thus, may not render some items like shulker boxes correctly.
- Adds fixes for player heads not rendering as expected when worn or on the ground.
- Added a fix for crossbows not showing if they're loaded. To other clients, they'll only see either a firework or an arrow.
- Items in creative will no longer be wiped of NBT if the NBT already exists in the inventory.
  - This however does rely on the `patchItemKickPatch` in its current state. It will fall through to the sanitiser if disabled.
- Some NBT string references in the minimizer methods has been swapped out to use the strings from items.
- The creative items check now has unnecessary-javadocitus

Fixes #41 - Creative inventories no longer get inadvertently sanitised for preexisting items by both `patchItemKickExploit` and `removeCreativeNbtTags`
Fixes #48 - Item names and heads show as expected now.
Needs verification for #45 for as this may fix the issue.