### PR TITLE
Update Minotaur & other loosely related changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           CURSEFORGE_API_KEY: ${{ secrets.CURSEFORGE_API_KEY }}
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-          CHANGELOG: ${{ steps.changelog.outputs.changelog }}
+          CHANGELOG: ${{ github.event.release.body }}
 
       - name: Upload GitHub release
         uses: AButler/upload-release-assets@v2.0

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,7 @@
-import com.modrinth.minotaur.TaskModrinthUpload
-
-
 plugins {
 	id 'fabric-loom' version '1.0-SNAPSHOT'
 	id 'com.matthewprenger.cursegradle' version '1.4.0'
-	id "com.modrinth.minotaur" version "1.1.0"
+	id "com.modrinth.minotaur" version "2.+"
 	id 'maven-publish'
 	id 'java'
 }
@@ -134,20 +131,23 @@ curseforge {
 	}
 }
 
-task modrinth(type: TaskModrinthUpload, dependsOn: remapJar) {
+tasks.modrinth {
 	onlyIf {
 		ENV.MODRINTH_TOKEN
 	}
+}
 
+modrinth {
 	token = ENV.MODRINTH_TOKEN
 	projectId = "PfKYAJGk"
 	versionNumber = version
 	versionName = "[${project.minecraft_version}] GolfIV ${version}"
-	releaseType = "release"
+	versionType = "release"
 	changelog = ENV.CHANGELOG ?: "A changelog can be found at https://github.com/samolego/GolfIV/releases/tag/${version}"
 
 	uploadFile = file("${project.buildDir}/libs/${archivesBaseName}-${version}.jar")
 
-	addGameVersion("${project.minecraft_version}")
-	addLoader('fabric')
+	gameVersions = [project.minecraft_version]
+	loaders = ['fabric', 'quilt']
 }
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             name = 'Fabric'
             url = 'https://maven.fabricmc.net/'


### PR DESCRIPTION
Fixes CI issues in part found in #70 and in release (see <https://github.com/samolego/GolfIV/actions/runs/4532813664/jobs/7984749401>)

Modrinth is deprecating their old API, and thus breaking old versions of Minotaur with it.

If old versions of Minotaur are also retracted, this would also go ahead and prevent builds from breaking via a missing plugin.